### PR TITLE
Break serve loop when network broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE
+.idea/
+*.iml


### PR DESCRIPTION
当handleConnect返回EOF错误时，通常意味着SSH通道已经断开，再继续使用循环旧的Listener对象将永远无法建立连接，此时不妨直接跳出for{}循环，让调用方接收到错误，并有机会用新的Listener来建立连接。

使用socks5连接到对端后，断开本地网络，几分钟后重新连接网络，即可制造出EOF错误的场景。