### PR TITLE
Fix hostname resolution in UDP target addresses

### DIFF
--- a/server.go
+++ b/server.go
@@ -390,10 +390,8 @@ func (s *Server) handleAssociate(req *request) error {
 			}
 			var targetIP net.IP
 			if targetAddr.IP != nil {
-				// socks5:// protocol with known IP
 				targetIP = targetAddr.IP
 			} else if targetAddr.Name != "" {
-				// socks5:// protocol, we need resolve domain name to IP address
 				ips, err := net.LookupIP(targetAddr.Name)
 				if err != nil {
 					if s.Logger != nil {


### PR DESCRIPTION
As described in the [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928#section-4), when the client uses `socks5h://` protocol, the client should send a domain name, which would be resolved on the proxy server.